### PR TITLE
Add Contains() function

### DIFF
--- a/ahocorasick.go
+++ b/ahocorasick.go
@@ -9,9 +9,7 @@
 
 package ahocorasick
 
-import (
-	"container/list"
-)
+import "container/list"
 
 // A node in the trie structure used to implement Aho-Corasick
 type node struct {
@@ -255,4 +253,30 @@ func (m *Matcher) Match(in []byte) []int {
 	}
 
 	return hits
+}
+
+// Contains returns true if any string matches. This can be faster
+// than Match() when you do not need to know which words matched.
+func (m *Matcher) Contains(in []byte) bool {
+	n := m.root
+	for _, b := range in {
+		c := int(b)
+		if !n.root {
+			n = n.fails[c]
+		}
+
+		if n.child[c] != nil {
+			f := n.child[c]
+			n = f
+
+			if f.output {
+				return true
+			}
+
+			for !f.suffix.root {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/ahocorasick_test.go
+++ b/ahocorasick_test.go
@@ -130,7 +130,7 @@ func TestWikipedia(t *testing.T) {
 }
 
 func TestMatch(t *testing.T) {
-	m := NewStringMatcher([]string{"Mozilla", "Mac", "Macintosh", "Safari", "Sausage"})
+	m := NewStringMatcher(dictionary)
 	hits := m.Match([]byte("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.101 Safari/537.36"))
 	assert(t, len(hits) == 4)
 	assert(t, hits[0] == 0)
@@ -155,6 +155,19 @@ func TestMatch(t *testing.T) {
 
 	hits = m.Match([]byte("Mazilla/5.0 (Moc; Intel Computer OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.101 Sofari/537.36"))
 	assert(t, len(hits) == 0)
+}
+
+func TestContains(t *testing.T) {
+	m := NewStringMatcher(dictionary)
+	contains := m.Contains([]byte("Mozilla/5.0 (Moc; Intel Computer OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.101 Sofari/537.36"))
+	assert(t, contains)
+
+	contains = m.Contains([]byte("Mazilla/5.0 (Moc; Intel Computer OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.101 Sofari/537.36"))
+	assert(t, !contains)
+
+	m = NewStringMatcher([]string{"SupermanX", "per"})
+	contains = m.Contains([]byte("The Man Of Steel: Superman"))
+	assert(t, contains == true)
 }
 
 var bytes = []byte("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.101 Safari/537.36")


### PR DESCRIPTION
This function shortcuts the normal process of finding strings, exiting early on the first string match. This can give a practical speed-up in cases where only existence of any string matters.