### PR TITLE
Add Contains() function

### DIFF
--- a/ahocorasick.go
+++ b/ahocorasick.go
@@ -304,3 +304,29 @@ func (m *Matcher) MatchThreadSafe(in []byte) []int {
 	m.heap.Put(heap)
 	return hits
 }
+
+// Contains returns true if any string matches. This can be faster
+// than Match() when you do not need to know which words matched.
+func (m *Matcher) Contains(in []byte) bool {
+	n := m.root
+	for _, b := range in {
+		c := int(b)
+		if !n.root {
+			n = n.fails[c]
+		}
+
+		if n.child[c] != nil {
+			f := n.child[c]
+			n = f
+
+			if f.output {
+				return true
+			}
+
+			for !f.suffix.root {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/ahocorasick_test.go
+++ b/ahocorasick_test.go
@@ -225,7 +225,7 @@ func TestWikipediaConcurrently(t *testing.T) {
 }
 
 func TestMatch(t *testing.T) {
-	m := NewStringMatcher([]string{"Mozilla", "Mac", "Macintosh", "Safari", "Sausage"})
+	m := NewStringMatcher(dictionary)
 	hits := m.Match([]byte("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.101 Safari/537.36"))
 	assert(t, len(hits) == 4)
 	assert(t, hits[0] == 0)
@@ -312,6 +312,20 @@ func TestLargeDictionaryMatchThreadSafeWorks(t *testing.T) {
 	 */
 	hits := precomputed6.MatchThreadSafe(bytes2)
 	assert(t, len(hits) == 105)
+
+}
+
+func TestContains(t *testing.T) {
+	m := NewStringMatcher(dictionary)
+	contains := m.Contains([]byte("Mozilla/5.0 (Moc; Intel Computer OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.101 Sofari/537.36"))
+	assert(t, contains)
+
+	contains = m.Contains([]byte("Mazilla/5.0 (Moc; Intel Computer OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.101 Sofari/537.36"))
+	assert(t, !contains)
+
+	m = NewStringMatcher([]string{"SupermanX", "per"})
+	contains = m.Contains([]byte("The Man Of Steel: Superman"))
+	assert(t, contains == true)
 }
 
 var bytes = []byte("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.101 Safari/537.36")


### PR DESCRIPTION
This function shortcuts the normal process of finding strings, exiting early on the first string match. This can give a practical speed-up in cases where only existence of any string matters.

This is the same as the earlier PR #5 but rebased to resolve conflicts.